### PR TITLE
Enable consule service discovery for hiveserver2

### DIFF
--- a/apps/beeswax/src/beeswax/conf.py
+++ b/apps/beeswax/src/beeswax/conf.py
@@ -45,6 +45,11 @@ HIVE_SERVER_PORT = Config(
   default=10000,
   type=int)
 
+HIVE_SERVER_CONSUL = Config(
+  key="hive_server_consul",
+  help=_t("HiveServer2 consul  url."),
+  default='')
+
 HIVE_CONF_DIR = Config(
   key='hive_conf_dir',
   help=_t('Hive configuration directory, where hive-site.xml is located.'),

--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -488,10 +488,10 @@ class HiveServerClient:
     self.user = user
     self.coordinator_host = ''
 
-    use_sasl, mechanism, kerberos_principal_short_name, impersonation_enabled, auth_username, auth_password = self.get_security()
+    use_sasl, mechanism, kerberos_principal_short_name, kerberos_principal_instance, impersonation_enabled, auth_username, auth_password = self.get_security()
     LOG.info(
-        '%s: server_host=%s, use_sasl=%s, mechanism=%s, kerberos_principal_short_name=%s, impersonation_enabled=%s, auth_username=%s' % (
-        self.query_server['server_name'], self.query_server['server_host'], use_sasl, mechanism, kerberos_principal_short_name, impersonation_enabled, auth_username)
+        '%s: server_host=%s, use_sasl=%s, mechanism=%s, kerberos_principal_short_name=%s, kerberos_principal_instance=%s, impersonation_enabled=%s, auth_username=%s' % (
+        self.query_server['server_name'], self.query_server['server_host'], use_sasl, mechanism, kerberos_principal_short_name, kerberos_principal_instance, impersonation_enabled, auth_username)
     )
 
     self.use_sasl = use_sasl
@@ -535,6 +535,7 @@ class HiveServerClient:
         query_server['server_port'],
         service_name=query_server['server_name'],
         kerberos_principal=kerberos_principal_short_name,
+        kerberos_principal_instance=kerberos_principal_instance,
         use_sasl=use_sasl,
         mechanism=mechanism,
         username=username,
@@ -558,9 +559,9 @@ class HiveServerClient:
     auth_password = self.query_server['auth_password']
 
     if principal:
-      kerberos_principal_short_name = principal.split('/', 1)[0]
+      kerberos_principal_short_name, kerberos_principal_instance = principal.split('@',1)[0].split('/', 1)
     else:
-      kerberos_principal_short_name = None
+      kerberos_principal_short_name = kerberos_principal_instance = None
 
     if self.query_server['server_name'].startswith('impala'):
       if auth_password: # Force LDAP/PAM.. auth if auth_password is provided
@@ -579,7 +580,7 @@ class HiveServerClient:
       mechanism = HiveServerClient.HS2_MECHANISMS[hive_mechanism]
       impersonation_enabled = hive_site.hiveserver2_impersonation_enabled()
 
-    return use_sasl, mechanism, kerberos_principal_short_name, impersonation_enabled, auth_username, auth_password
+    return use_sasl, mechanism, kerberos_principal_short_name, kerberos_principal_instance, impersonation_enabled, auth_username, auth_password
 
 
   def open_session(self, user):

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -95,9 +95,9 @@ syncdb: $(DESKTOP_DB)
 
 $(DESKTOP_DB): $(BLD_DIR_BIN)/hue
 	@if [ -n "$(DESKTOP_DEBUG)" ]; then \
-	  @echo "--- Regenerating database at $@" \
-	  @echo 'Removing old database (DESKTOP_DEBUG is set)' ; \
-	  @rm -f $@ ; \
+	  echo "--- Regenerating database at $@" \
+	  echo 'Removing old database (DESKTOP_DEBUG is set)' ; \
+	  rm -f $@ ; \
 	fi
 
 # Targets that simply recurse into all of the applications

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import q
 import Queue
 import logging
 import socket

--- a/desktop/core/src/desktop/lib/thrift_util.py
+++ b/desktop/core/src/desktop/lib/thrift_util.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import q
 import Queue
 import logging
 import socket
@@ -82,6 +82,7 @@ class ConnectionConfig(object):
                use_sasl=False,
                use_ssl=False,
                kerberos_principal="thrift",
+               kerberos_principal_instance=None,
                mechanism='GSSAPI',
                username='hue',
                password='hue',
@@ -129,6 +130,7 @@ class ConnectionConfig(object):
     self.username = username
     self.password = password
     self.kerberos_principal = kerberos_principal
+    self.kerberos_principal_instance = kerberos_principal_instance
     self.ca_certs = ca_certs
     self.keyfile = keyfile
     self.certfile = certfile
@@ -141,7 +143,7 @@ class ConnectionConfig(object):
     self.coordinator_host = coordinator_host
 
   def __str__(self):
-    return ', '.join(map(str, [self.klass, self.host, self.port, self.service_name, self.use_sasl, self.kerberos_principal, self.timeout_seconds,
+    return ', '.join(map(str, [self.klass, self.host, self.port, self.service_name, self.use_sasl, self.kerberos_principal, self.kerberos_principal_instance, self.timeout_seconds,
                                self.mechanism, self.username, self.use_ssl, self.ca_certs, self.keyfile, self.certfile, self.validate, self.transport,
                                self.multiple, self.transport_mode, self.http_url, self.coordinator_host]))
 
@@ -314,8 +316,9 @@ def connect_to_thrift(conf):
   if conf.transport_mode == 'socket' and conf.use_sasl:
     def sasl_factory():
       saslc = sasl.Client()
-      saslc.setAttr("host", str(conf.host))
+      saslc.setAttr("host", str(conf.kerberos_principal_instance))
       saslc.setAttr("service", str(conf.kerberos_principal))
+
       if conf.mechanism == 'PLAIN':
         saslc.setAttr("username", str(conf.username))
         saslc.setAttr("password", str(conf.password)) # Defaults to 'hue' for a non-empty string unless using LDAP


### PR DESCRIPTION
The proper solution is to have a proxy server
for hiveserver2 instances, but it can be more complicated
in configuration.