### PR TITLE
A few more minor sqlalchemy adjustments

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -333,6 +333,22 @@ class SqlAlchemyApi(Api):
     finally:
       return result
 
+  @query_error_handler
+  def explain(self, notebook, snippet):
+    engine = self._create_engine()
+    statement = snippet['statement'].rstrip(';')
+    try:
+      with engine.connect() as connection:
+        result = connection.execute('explain ' + statement)
+        rows = result.fetchall()
+      explanation = '\n'.join(row[0] for row in rows)
+      return {
+        'status': 0,
+        'explanation': explanation,
+        'statement': statement,
+      }
+    finally:
+      engine.dispose()
 
   @query_error_handler
   def autocomplete(self, snippet, database=None, table=None, column=None, nested=None):

--- a/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
+++ b/desktop/libs/notebook/src/notebook/connectors/sql_alchemy.py
@@ -111,7 +111,7 @@ class SqlAlchemyApi(Api):
     if interpreter.get('dialect_properties'):
       self.backticks = interpreter['dialect_properties']['sql_identifier_quote']
     else:
-      self.backticks = '"' if re.match('^(postgresql://|awsathena|elasticsearch)', self.options.get('url', '')) else '`'
+      self.backticks = '"' if re.match('^((postgresql|presto|vertica)([+][^:]+)?://|awsathena|elasticsearch|)', self.options.get('url', '')) else '`'
 
   def _create_engine(self):
     if '${' in self.options['url']: # URL parameters substitution


### PR DESCRIPTION
- Use double quotes for identifiers in Vertica and Presto, which fixes autogenerated queries, such as the one to get sample data in the Table Browser
- Add explain() method to sql_alchemy, to be able to push the "Explain" button in the UI
- Fetch cursor description before fetching first row in sql_alchemy, fixing empty results appearing the same as queries with no result