### PR TITLE
Provide slack unfurl endpoint

### DIFF
--- a/desktop/core/src/desktop/api_public_urls.py
+++ b/desktop/core/src/desktop/api_public_urls.py
@@ -19,6 +19,8 @@ import sys
 
 from desktop import api_public
 from desktop.lib.botserver import api as botserver_api
+from desktop.lib.botserver import views as botserver_views
+from desktop.conf import SLACK
 
 if sys.version_info[0] > 2:
   from django.urls import re_path
@@ -111,6 +113,11 @@ urlpatterns += [
 urlpatterns += [
   re_path(r'^slack/install/?$', botserver_api.generate_slack_install_link, name='botserver.api.slack_install_link'),
 ]
+
+if SLACK.IS_ENABLED.get():
+  urlpatterns += [
+    re_path(r'^unfurl/?$', botserver_views.slack_unfurl, name='botserver.views.slack_unfurl'),
+  ]
 
 urlpatterns += [
   re_path(r'^indexer/guess_format/?$', api_public.guess_format, name='indexer_guess_format'),

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -758,6 +758,12 @@ SLACK = ConfigSection(
       type=coerce_bool,
       default=True,
     ),
+    SHARE_QUERY_RESULTS=Config(
+      key='share_query_results',
+      help=_('Enable data sample when sharing queries on Slack'),
+      type=coerce_bool,
+      default=False,
+    )
   )
 )
 

--- a/desktop/core/src/desktop/lib/botserver/slack_client.py
+++ b/desktop/core/src/desktop/lib/botserver/slack_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Licensed to Cloudera, Inc. under one
-# or more contributor license agreements.  See the NOTICE file
+# or m ore contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  Cloudera, Inc. licenses this file
 # to you under the Apache License, Version 2.0 (the
@@ -15,12 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from desktop import conf
 
 SLACK_VERIFICATION_TOKEN = conf.SLACK.SLACK_VERIFICATION_TOKEN.get()
 SLACK_BOT_USER_TOKEN = conf.SLACK.SLACK_BOT_USER_TOKEN.get()
 
 slack_client = None
-if conf.SLACK.IS_ENABLED.get():
-  from slack_sdk import WebClient
-  slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)
+if conf.SLACK.IS_ENABLED.get() & sys.version_info[0] > 2:
+    from slack_sdk import WebClient
+    slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)

--- a/desktop/core/src/desktop/lib/botserver/slack_client.py
+++ b/desktop/core/src/desktop/lib/botserver/slack_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Licensed to Cloudera, Inc. under one
-# or m ore contributor license agreements.  See the NOTICE file
+# or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  Cloudera, Inc. licenses this file
 # to you under the Apache License, Version 2.0 (the
@@ -24,5 +24,5 @@ SLACK_BOT_USER_TOKEN = conf.SLACK.SLACK_BOT_USER_TOKEN.get()
 
 slack_client = None
 if conf.SLACK.IS_ENABLED.get() & sys.version_info[0] > 2:
-    from slack_sdk import WebClient
-    slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)
+  from slack_sdk import WebClient
+  slack_client = WebClient(token=SLACK_BOT_USER_TOKEN)

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -22,6 +22,8 @@ import os
 from urllib.parse import urlsplit
 from tabulate import tabulate
 
+from desktop import conf
+
 from desktop.lib.botserver.slack_client import slack_client, SLACK_VERIFICATION_TOKEN
 from desktop.lib.botserver.api import _send_message
 from desktop.lib.django_util import login_notrequired, JsonResponse
@@ -352,7 +354,7 @@ def _make_unfurl_payload(request, url, id_type, doc, doc_type):
   file_status = False
   result_section = None
 
-  if id_type == 'editor':
+  if (id_type == 'editor') & conf.SLACK.SHARE_QUERY_RESULTS.get():
     max_rows = 2
     unfurl_result = 'Query result has expired or could not be found'
 

--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -28,6 +28,8 @@ from desktop.lib.botserver.slack_client import slack_client, SLACK_VERIFICATION_
 from desktop.lib.botserver.api import _send_message
 from desktop.lib.django_util import login_notrequired, JsonResponse
 from desktop.lib.exceptions_renderable import PopupException
+
+from desktop.decorators import api_error_handler
 from desktop.models import Document2, _get_gist_document, get_cluster_config
 from desktop.api2 import _gist_create
 from desktop.auth.backend import rewrite_user
@@ -262,6 +264,53 @@ def handle_on_link_shared(host_domain, channel_id, message_ts, links, user_id):
       send_result_file(request, channel_id, message_ts, doc, 'xls')
 
 
+@login_notrequired
+@csrf_exempt
+@api_error_handler
+def slack_unfurl(request):
+  try:
+    body = json.loads(request.body)
+    link = body.get('url')
+    user = body.get('user')
+    payload = handle_on_unfurl(link, user)
+  except ValueError as err:
+    raise PopupException(_("Response content is not valid JSON"), detail=err)
+
+  return JsonResponse(payload)
+
+def handle_on_unfurl(url, user):
+  path = urlsplit(url)[2]
+  id_type, qid = urlsplit(url)[3].split('=')
+  query_id = {'id': qid} if qid.isdigit() else {'uuid': qid}
+
+  try:
+    if path == '/hue/editor' and id_type == 'editor':
+      doc = Document2.objects.get(**query_id)
+      doc_type = 'query'
+    elif path == '/hue/gist' and id_type == 'uuid':
+      doc = _get_gist_document(**query_id)
+      doc_type = 'gist'
+    else:
+      err_msg = 'Could not access the query, please check the link again.'
+      raise SlackBotException(_(err_msg))
+  except Document2.DoesNotExist:
+    err_msg = 'Query document not found or does not exist.'
+    raise SlackBotException(_(err_msg))
+
+  try:
+    u = User.objects.get(username=user)
+  except User.DoesNotExist:
+    raise SlackBotException(_("Slack user does not have access to the query"))
+
+  doc.can_read_or_exception(u)
+
+  request = MockRequest(user=rewrite_user(u))
+
+  payload = _make_unfurl_payload(request, url, id_type, doc, doc_type)['payload'][url]
+  return payload
+
+
+
 def get_user(channel_id, slack_user, message_ts):
   try:
     return User.objects.get(username=slack_user.get('user_email_prefix'))
@@ -381,7 +430,7 @@ def _make_unfurl_payload(request, url, id_type, doc, doc_type):
     'name': doc.name,
     'doc_type': doc_type,
     'dialect': dialect,
-    'user': doc.owner.get_full_name() or doc.owner.username,
+    'user': doc.owner.username,
     'query': statement if len(statement) < 150 else (statement[:150] + '...'),
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Do not create Slack Web client when Python version < 3
- Provide flag to explicitly share unfurl query result
- Provide endpoint for Slack unfurling
