### PR TITLE
[notebook] - Add right panel for Presto SQLAlchemy

### DIFF
--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -145,7 +145,7 @@ def get_ordered_interpreters(user=None):
       'dialect_properties': i.get('dialect_properties') or {},  # Empty when connectors off
       'category': i.get('category', 'editor'),
       "is_sql": i.get('is_sql') or \
-          i['interface'] in ["hiveserver2", "rdbms", "jdbc", "solr", "sqlalchemy", "ksql", "flink"] or \
+          i['interface'] in ["hiveserver2", "rdbms", "jdbc", "solr", "presto-sqlalchemy", "sqlalchemy", "ksql", "flink"] or \
           i['type'] in ["sql", "sparksql"],
       "is_catalog": i['interface'] in ["hms",],
     }


### PR DESCRIPTION
Make Presto SQL alchemy part of the is_sql interfaces. 
This will enable the right panel assistant for this connector.