### PR TITLE
[WIP] Annotate consul logic for multi-hive support preparation

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -338,6 +338,17 @@ def get_query_server_config(name='beeswax', connector=None):
           'use_sasl': SPARK_USE_SASL.get()
       })
 
+    if 'service' in connector['options']:
+      query_server['crto_hs2_service'] = connector['options']['service']
+
+    if 'dc' in connector['options']:
+      query_server['crto_dc'] = connector['options']['dc']
+
+    if 'env' in connector['options']:
+      query_server['crto_env'] = connector['options']['env']
+
+    query_server['crto_connector_type'] = connector['type']
+
   if not query_server.get('dialect'):
     query_server['dialect'] = query_server['server_name']
 
@@ -416,8 +427,6 @@ def get_query_server_config_via_connector(connector):
       'SESSION_TIMEOUT_S': 15 * 60,
       'querycache_rows': 1000,
       'QUERY_TIMEOUT_S': 15 * 60,
-      # Prefixed custom server config
-      'crto_service': connector['options'][''],
   }
 
   if 'service' in connector['options']:
@@ -428,6 +437,8 @@ def get_query_server_config_via_connector(connector):
 
   if 'env' in connector['options']:
     server_config['crto_env'] = connector['options']['env']
+
+  server_config['crto_connector_type'] = connector['type']
 
   return server_config
 

--- a/apps/beeswax/src/beeswax/server/hive_server2_lib.py
+++ b/apps/beeswax/src/beeswax/server/hive_server2_lib.py
@@ -666,7 +666,14 @@ class HiveServerClient(object):
         'username': user.username,  # If SASL or LDAP, it gets the username from the authentication mechanism since it dependents on it.
         'configuration': {},
     }
-    connector_type = 'hive' if self.query_server['server_name'] == 'beeswax' else self.query_server['server_name']
+    ## Bug there
+    connector_type = None
+    if self.query_server['crto_connector_type']:
+      connector_type = self.query_server['crto_connector_type']
+    elif self.query_server['server_name'] == 'beeswax':
+      connector_type = 'hive'
+    else:
+      connector_type = self.query_server['server_name']
     interpreter = get_interpreter(connector_type=connector_type, user=self.user)
 
     if self.impersonation_enabled:

--- a/desktop/libs/notebook/src/notebook/api.py
+++ b/desktop/libs/notebook/src/notebook/api.py
@@ -150,6 +150,8 @@ def _execute_notebook(request, notebook, snippet):
         history = _historify(notebook, request.user)
         notebook = Notebook(document=history).get_data()
 
+      # DATADEV-3042
+      # Gets the interpreter from the list defined in hue.ini
       interpreter = get_api(request, snippet)
       if snippet.get('interface') == 'sqlalchemy':
         interpreter.options['session'] = sessions[0]
@@ -158,6 +160,8 @@ def _execute_notebook(request, notebook, snippet):
         # interpreter.execute needs the sessions, but we don't want to persist them
         pre_execute_sessions = notebook['sessions']
         notebook['sessions'] = sessions
+        # DATADEV-3042
+        # In case of hive query, resolves to notebook.connectors.hiveserver2.HS2Api.execute
         response['handle'] = interpreter.execute(notebook, snippet)
         notebook['sessions'] = pre_execute_sessions
 

--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -716,7 +716,13 @@ DROP TABLE IF EXISTS `%(table)s`;
     if session:
       session_id = session.get('id')
       if session_id:
-        filters = {'id': session_id, 'application': 'beeswax' if type == 'hive' or type == 'llap' or type.startswith('hive') else type}
+        filters = {
+          'id': session_id,
+          'application': 'beeswax' if type == 'hive'
+                                   or type == 'llap'
+                                   or self.interpreter['interface'] == 'hiveserver2'
+                                   else type
+        }
         if not is_admin(self.user):
           filters['owner'] = self.user
         return Session.objects.get(**filters)

--- a/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
+++ b/desktop/libs/notebook/src/notebook/connectors/hiveserver2.py
@@ -313,6 +313,8 @@ class HS2Api(Api):
 
   @query_error_handler
   def execute(self, notebook, snippet):
+    # DATADEV-3042
+    # Consul resolution gets done in there
     db = self._get_db(snippet, interpreter=self.interpreter)
 
     statement = self._get_current_statement(notebook, snippet)
@@ -802,6 +804,8 @@ DROP TABLE IF EXISTS `%(table)s`;
     return HiveServerQueryHandle(**handle)
 
 
+  # DATADEV-3042
+  # interpreter may have an option attribute to select DC if configured
   def _get_db(self, snippet, is_async=False, interpreter=None):
     if interpreter and interpreter.get('dialect'):
       dialect = interpreter['dialect']
@@ -822,6 +826,8 @@ DROP TABLE IF EXISTS `%(table)s`;
       name = 'sparksql'
 
     # Note: name is not used if interpreter is present
+    # DATADEV-3042
+    # In dbms.get we do the consul resolution. get_query_server_config
     return dbms.get(self.user, query_server=get_query_server_config(name=name, connector=interpreter))
 
 

--- a/tools/docker/dev/Dockerfile_2204
+++ b/tools/docker/dev/Dockerfile_2204
@@ -1,0 +1,47 @@
+# Welcome to Hue (http://gethue.com) Dockerfile
+# Build an image from a remote github or local cloned Hue repository.
+
+FROM ubuntu:22.04
+LABEL description="Hue Project https://github.com/cloudera/hue"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y && apt-get install -y \
+    build-essential \
+    libkrb5-dev \
+    libmysqlclient-dev \
+    libssl-dev \
+    libsasl2-dev \
+    libsasl2-modules-gssapi-mit \
+    libsqlite3-dev \
+    libtidy-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libffi-dev \
+    libldap2-dev \
+    libpq-dev \
+    asciidoc \
+    python2-dev \
+    python-setuptools \
+    libgmp3-dev \
+    libz-dev \
+    software-properties-common \
+    curl \
+    git \
+    rsync \
+    sudo \
+    maven \
+    gcc \
+    swig \
+    # openssl \ # Breaks build
+    xmlsec1 \
+    libxmlsec1-openssl \
+    hugo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Need recent version for Ubuntu
+RUN curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
+    && apt-get install -y nodejs
+
+ENV HOME=/tmp
+


### PR DESCRIPTION
Proposed change:

To add a new hive instance, we should use the "option" field of the interpreter config.
For the moment, we use it as:
```
[[[hive]]]
  # The name of the snippet.
  name=Hive
  # The backend connection to use to communicate with the server.
  interface=hiveserver2
```

I suggest to do the following:
```
[[[hivefr4-preprod]]]
  # The name of the snippet.
  name=Hive FR4
  # The backend connection to use to communicate with the server.
  interface=hiveserver2
  options='{"dc": "FR4", "service": "2-main", "env": "preprod"}'
[[[hiveam6]]]
  # The name of the snippet.
  name=Hive AM6
  # The backend connection to use to communicate with the server.
  interface=hiveserver2
  options='{"dc": "AM6", "service": "2-main", "env": "prod"}'
[[[hiveiceberg]]]
  # The name of the snippet.
  name=Hive Iceberg
  # The backend connection to use to communicate with the server.
  interface=hiveserver2
  options='{"dc": "FR4", "service": "iceberg", "env": "prod"}'
```

The code I've annotated are the whole path of that a hue request takes to be resolved to a given hive instance.