### PR TITLE
[botserver] - Fetch user by email instead of username

### DIFF
--- a/desktop/core/src/desktop/lib/botserver/views.py
+++ b/desktop/core/src/desktop/lib/botserver/views.py
@@ -298,7 +298,7 @@ def handle_on_unfurl(url, user):
     raise SlackBotException(_(err_msg))
 
   try:
-    u = User.objects.get(username=user)
+    u = User.objects.get(email=user)
   except User.DoesNotExist:
     raise SlackBotException(_("Slack user does not have access to the query"))
 


### PR DESCRIPTION
When unfurl, the user that posted the url is now retrieved via its email instead of its username.
