### PR TITLE
Rework consul discovery logic

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 import re
-import sys
 import random
 
 import requests
@@ -80,30 +79,6 @@ from desktop.settings import CACHES_HIVE_DISCOVERY_KEY
 from indexer.file_format import HiveFormat
 from libzookeeper import conf as libzookeeper_conf
 
-from azure.abfs import abfspath
-from beeswax.conf import HIVE_SERVER_HOST, HIVE_SERVER_PORT, HIVE_SERVER_HOST, HIVE_HTTP_THRIFT_PORT, HIVE_METASTORE_HOST, \
-    HIVE_METASTORE_PORT, LIST_PARTITIONS_LIMIT, SERVER_CONN_TIMEOUT, ZOOKEEPER_CONN_TIMEOUT, \
-    AUTH_USERNAME, AUTH_PASSWORD, APPLY_NATURAL_SORT_MAX, QUERY_PARTITIONS_LIMIT, HIVE_DISCOVERY_HIVESERVER2_ZNODE, \
-    HIVE_DISCOVERY_HS2, HIVE_DISCOVERY_LLAP, HIVE_DISCOVERY_LLAP_HA, HIVE_DISCOVERY_LLAP_ZNODE, CACHE_TIMEOUT, \
-    LLAP_SERVER_HOST, LLAP_SERVER_PORT, LLAP_SERVER_THRIFT_PORT, USE_SASL as HIVE_USE_SASL, CLOSE_SESSIONS, has_session_pool, \
-    MAX_NUMBER_OF_SESSIONS
-from beeswax.common import apply_natural_sort, is_compute
-from beeswax.design import hql_query
-from beeswax.hive_site import hiveserver2_use_ssl, hiveserver2_impersonation_enabled, get_hiveserver2_kerberos_principal, \
-    hiveserver2_transport_mode, hiveserver2_thrift_http_path
-from beeswax.models import QueryHistory, QUERY_TYPES
-
-
-if sys.version_info[0] > 2:
-  from django.utils.encoding import force_str
-else:
-  from django.utils.encoding import force_unicode as force_str
-
-if sys.version_info[0] > 2:
-  from django.utils.translation import gettext as _
-else:
-  from django.utils.translation import ugettext as _
-
 LOG = logging.getLogger()
 
 
@@ -144,18 +119,7 @@ def get(user, query_server=None, cluster=None):
   global RESET_HS2_QUERY_SERVER
 
   if query_server is None:
-    query_server = get_query_server_config(cluster=cluster)
-
-  # ---------------------------------------------------------------------------
-  # Consul logic
-  # ---------------------------------------------------------------------------
-  consul = HIVE_SERVER_CONSUL.get()
-  nodes = None
-  if consul:
-    nodes = get_nodes_from_consul(consul)
-    if not nodes:
-      LOG.error("No healthy nodes in consul %s" % consul)
-  # ---------------------------------------------------------------------------
+    query_server = get_query_server_config(connector=cluster)
 
   # if the auth_username is not set then we attempt to set using the current user
   # this is likely to be the case when using connectors/computes
@@ -165,28 +129,10 @@ def get(user, query_server=None, cluster=None):
   DBMS_CACHE_LOCK.acquire()
   try:
     DBMS_CACHE.setdefault(user.id, {})
-    # -------------------------------------------------------------------------
-    # If we get nodes from consul check thaty the current client use a healthy
-    # node
-    # -------------------------------------------------------------------------
-    node_not_available = False
-    if nodes and (query_server['server_name'] in DBMS_CACHE[user.id]):
-      server = DBMS_CACHE[user.id][query_server['server_name']]
 
-      current_host = server.client.query_server['server_host']
-      current_port = server.client.query_server['server_port']
-
-      if (current_host, current_port) not in nodes:
-        LOG.debug("Current server is down: %s:%d" % (current_host, current_port))
-        node_not_available = True
-    # -------------------------------------------------------------------------
-    if node_not_available or (query_server['server_name'] not in DBMS_CACHE[user.id]):
+    if query_server['server_name'] not in DBMS_CACHE[user.id]:
       # Avoid circular dependency
       from beeswax.server.hive_server2_lib import HiveServerClientCompatible
-      if nodes:
-        node = random.sample(nodes, 1)[0] # Some kind of Load Balancing
-        query_server.update({'server_host': node[0], 'server_port': node[1]})
-        LOG.debug("Use server from consul: %s:%d" % (query_server['server_host'], query_server['server_port']))
 
       if query_server.get('dialect') == 'impala':
         from impala.dbms import ImpalaDbms
@@ -216,10 +162,6 @@ def get(user, query_server=None, cluster=None):
         HiveServerClientCompatible(HiveServerClient(query_server, user)),
         QueryHistory.SERVER_TYPE[1][0]
       )
-    debug_query_server =  DBMS_CACHE[user.id][query_server['server_name']].client.query_server.copy()
-    debug_query_server['auth_password_used'] = bool(debug_query_server.pop('auth_password'))
-    LOG.debug("Query Server: %s" % debug_query_server)
-
     return DBMS_CACHE[user.id][query_server['server_name']]
   finally:
     DBMS_CACHE_LOCK.release()
@@ -299,6 +241,23 @@ def get_query_server_config(name='beeswax', connector=None):
               "port": hiveservers[server_to_use].split(";")[0].split("=")[1].split(":")[1]
             })
           )
+        elif HIVE_SERVER_CONSUL.get():
+          # Hive discovery through consul
+          consul = HIVE_SERVER_CONSUL.get()
+          nodes = get_nodes_from_consul(consul)
+          LOG.debug("Available Hive Servers: {0}".format(nodes))
+          if not nodes:
+            LOG.error('There are no running Hive server available on Consul')
+            raise PopupException(_('There are no running Hive server available'))
+          node = random.sample(nodes, 1)[0]
+          LOG.debug("Selected Hive server: {0}". format(node))
+          cache.set(
+            "hiveserver2",
+            json.dumps({
+              "host": node[0],
+              "port": node[1]
+            })
+          )
         else:
           cache.set("hiveserver2", json.dumps({
             "host": HIVE_SERVER_HOST.get(),
@@ -329,6 +288,29 @@ def get_query_server_config(name='beeswax', connector=None):
           else:
             LOG.error('Currently there are no HiveServer2 running')
             raise PopupException(_('Currently there are no HiveServer2 running'))
+        elif HIVE_SERVER_CONSUL.get():
+          # Replace active endpoint if current HS2 is down
+          consul = HIVE_SERVER_CONSUL.get()
+          nodes = get_nodes_from_consul(consul)
+
+          if nodes:
+            current_hs2 = json.loads(cache.get("hiveserver2"))
+            current_hs2_found_in_active_nodes = next((node for node in nodes if current_hs2['host'] == node[0] and current_hs2['port'] == node[1]), None)
+            if current_hs2_found_in_active_nodes is None:
+              LOG.error('Current HiveServer is down, selecting another available HiveServer from consul')
+              reset_ha()
+              node = random.sample(nodes, 1)[0]
+              LOG.debug("Selected Hive server: {0}". format(node))
+              cache.set(
+                "hiveserver2",
+                json.dumps({
+                  "host": node[0],
+                  "port": node[1]
+                })
+              )
+          else:
+            LOG.error('There are no running Hive server available on Consul')
+            raise PopupException(_('There are no running Hive server available'))
         else:
           # Setting hs2 cache in-case there is no HS2 discovery
           cache.set("hiveserver2", json.dumps({


### PR DESCRIPTION
- Discovery behavior matches the native zookeeper HA hive setup of selecting only one Hive instance for the whole hue instance
- Consul logic is integrated into get_query_server_config instead of trying to update the hive host/port at the last moment
- Fix duplicated imports

This change brings the get() function to be the same as the upstream/cloudera version.
What changes are made to get_query_server_config() are new branches in conditional statements, and does not modify any lines existing in the upstream. This should result in a diff between upstream and our fork that consists entirely in added lines