### PR TITLE
Random pick of instance from consul is done on list

### DIFF
--- a/apps/beeswax/src/beeswax/server/dbms.py
+++ b/apps/beeswax/src/beeswax/server/dbms.py
@@ -387,7 +387,7 @@ def get_nodes_from_consul(consul):
     port =  item['Service']['Port']
     result.add((address, port))
 
-  return result
+  return list(result)
 
 def get_query_server_config_via_connector(connector):
   # TODO: connector is actually a notebook interpreter


### PR DESCRIPTION
Python 3.11 no longer allows to run random.sample on a set. We need to explicitly convert the set of consul instances to a list
iv