### PR TITLE
Fix oracle-cx build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,11 @@ $(BLD_DIR_ENV)/stamp:
 	  echo '--- Finished $(REQUIREMENT_PPC64LE_FILE) into virtual-env'; \
 	 else \
 	  echo '--- Installing $(REQUIREMENT_FILE) into virtual-env via $(ENV_PIP)'; \
-	  $(ENV_PIP) install -r $(REQUIREMENT_FILE); \
+		echo "--- Using build constraints to prevent setuptools 82+ (cx-Oracle compatibility) ---"; \
+	  PIP_CONSTRAINT=$(ROOT)/desktop/core/build-constraints.txt $(ENV_PIP) install -r $(REQUIREMENT_FILE); \
 	  echo '--- Finished $(REQUIREMENT_FILE) into virtual-env'; \
          fi
-	@$(ENV_PIP) install $(NAVOPTAPI_WHL)
+	PIP_CONSTRAINT=$(ROOT)/desktop/core/build-constraints.txt $(ENV_PIP) install $(NAVOPTAPI_WHL)
 	@echo '--- Finished $(NAVOPTAPI_WHL) into virtual-env'
 	@touch $(REQUIREMENT_DOT_FILE)
 ###################################

--- a/desktop/core/build-constraints.txt
+++ b/desktop/core/build-constraints.txt
@@ -1,0 +1,4 @@
+# build-time constraints to prevent setuptools 82+ from breaking cx-oracle
+# see: https://github.com/oracle/python-cx_oracle/blob/main/setup.py (imports pkg_resources)
+# setuptools 82+ removed pkg_resources, causing build failures
+setuptools<82


### PR DESCRIPTION
Backport of upstream 07a8dc357e93ae08ede8ba6321236f1f6447aa80 reverting the setuptools breaking changes. Adapted to fit Makefile structure from before multi-python support introduced in de00238a35a723f035064bb38f9a6dd924dd1730

## What changes were proposed in this pull request?

- (Please fill in changes proposed in this fix)

## How was this patch tested?

- (Please explain how this patch was tested. Ex: unit tests, manual tests)
- (If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
